### PR TITLE
Enum customization & export statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ junitPlatform {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://dl.bintray.com/jetbrains/spek" }
     mavenCentral()
 }
 
@@ -51,8 +50,8 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     testCompile 'com.winterbe:expekt:0.5.0'
-    testCompile 'org.jetbrains.spek:spek-api:1.1.0-beta3'
+    testCompile 'org.jetbrains.spek:spek-api:1.1.0'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.0.0-M3'
-    testRuntime 'org.jetbrains.spek:spek-junit-platform-engine:1.1.0-beta3'
+    testRuntime 'org.jetbrains.spek:spek-junit-platform-engine:1.1.0'
     testCompile 'com.google.code.findbugs:jsr305:3.0.1'
 }

--- a/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
+++ b/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
@@ -78,7 +78,8 @@ class TypeScriptGenerator(
     private val mappings: Map<KClass<*>, String> = mapOf(),
     classTransformers: List<ClassTransformer> = listOf(),
     ignoreSuperclasses: Set<KClass<*>> = setOf(),
-    private val intTypeName: String = "number"
+    private val intTypeName: String = "number",
+    addExportStatements: Boolean = false
 ) {
     private val visitedClasses: MutableSet<KClass<*>> = java.util.HashSet()
     private val generatedDefinitions = mutableListOf<String>()
@@ -88,6 +89,7 @@ class TypeScriptGenerator(
         java.io.Serializable::class,
         Comparable::class
     ).plus(ignoreSuperclasses)
+    private val export = if (addExportStatements) "export " else ""
 
     init {
         rootClasses.forEach { visitClass(it) }
@@ -186,6 +188,7 @@ class TypeScriptGenerator(
         return "type ${klass.simpleName} = ${klass.java.enumConstants
             .map { constant: Any ->
                 constant.toString().toJSString()
+        return "${export}type ${klass.simpleName} = ${klass.java.enumConstants
             }
             .joinToString(" | ")
         };"
@@ -221,6 +224,7 @@ class TypeScriptGenerator(
         }
 
         return "interface ${klass.simpleName}$templateParameters$extendsString {\n" +
+        return "${export}interface ${klass.simpleName}$templateParameters$extendsString {\n" +
             klass.declaredMemberProperties
                 .filter { !isFunctionType(it.returnType.javaType) }
                 .filter {

--- a/src/main/kotlin/me/ntrrgc/tsGenerator/defaultEnumTransformer.kt
+++ b/src/main/kotlin/me/ntrrgc/tsGenerator/defaultEnumTransformer.kt
@@ -1,0 +1,5 @@
+package me.ntrrgc.tsGenerator
+
+import kotlin.reflect.KClass
+
+fun defaultEnumTransformer(klass: KClass<*>, enumValue: Any) = enumValue.toString()


### PR DESCRIPTION
Hi,

I've added two new (small) features that I needed:
* I wanted to be able to generate TS definitions like this:
```ts
export interface Foo {
    bar: int;
}
```

This is so I can use them independently, as opposed to as type definitions for other code. To this end I've added a new optional parameter `addExportStatements`. When true, `export` statements are added.

Secondly, I wanted to be able to customise enum output, so instead of getting ALLCAPS enums, as is the convention in Java/Kotlin, I could have lowercase enums to match my JSON API.

So I've added an `enumTransformer` parameter. It is a function that takes the enum class (`KClass<*>`) and the enum value and returns a string. For my task (lowercase enums) I didn't need per-class behaviour, nor is it needed in the default case. However, I thought that some users might want to format some enums differently than others, so I added that as a parameter.

If you're happy with the thrust of these changes, I will write unit tests for them as well, if you would like me too. I didn't want to write unit tests for them until I found out whether you were happy with this API/approach.

Thanks for writing a really useful library!