### PR TITLE
Fixed mapping alias with nullable types

### DIFF
--- a/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
+++ b/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
@@ -123,7 +123,7 @@ class TypeScriptGenerator(
         if (classifier is KClass<*>) {
             val existingMapping = mappings[classifier]
             if (existingMapping != null) {
-                return TypeScriptType.single(mappings[classifier]!!, false, voidType)
+                return TypeScriptType.single(mappings[classifier]!!, kType.isMarkedNullable, voidType)
             }
         }
 

--- a/src/test/kotlin/me/ntrrgc/tsGenerator/tests/generatorTests.kt
+++ b/src/test/kotlin/me/ntrrgc/tsGenerator/tests/generatorTests.kt
@@ -74,6 +74,10 @@ class Widget(
 class ClassWithDependencies(
     val widget: Widget
 )
+class ClassWithMixedNullables(
+    val count: Int,
+    val time: Instant?
+)
 class ClassWithNullables(
     val widget: Widget?
 )
@@ -173,6 +177,24 @@ interface ClassWithMember {
         widget: Widget | null;
     }
     """, widget))
+    }
+
+    it("handles ClassWithMixedNullables using mapping") {
+        assertGeneratedCode(ClassWithMixedNullables::class, setOf("""
+    interface ClassWithMixedNullables {
+        count: int;
+        time: string | null;
+    }
+    """), mappings = mapOf(Instant::class to "string"))
+    }
+
+    it("handles ClassWithMixedNullables using mapping and VoidTypes") {
+        assertGeneratedCode(ClassWithMixedNullables::class, setOf("""
+    interface ClassWithMixedNullables {
+        count: int;
+        time: string | undefined;
+    }
+    """), mappings = mapOf(Instant::class to "string"), voidType = VoidType.UNDEFINED)
     }
 
     it("handles ClassWithComplexNullables") {


### PR DESCRIPTION
Hi! I've added a quick change to make sure nullable types are handled when a mapping alias is set.

This PR includes:

- Replaced hardcoded `false` param by `kType.isMarkedNullable`
- Added tests for both VoidType entries.

ts-generator is great, saved us a lot of time. Thanks for publishing it! 🙂

