### PR TITLE
Support extending generic superclasses.

### DIFF
--- a/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
+++ b/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
@@ -194,11 +194,11 @@ class TypeScriptGenerator(
     }
 
     private fun generateInterface(klass: KClass<*>): String {
-        val superclasses = klass.superclasses
-            .filterNot { it in ignoredSuperclasses }
-        val extendsString = if (superclasses.isNotEmpty()) {
-            " extends " + superclasses
-                .map { formatClassType(it) }
+        val supertypes = klass.supertypes
+            .filterNot { it.classifier in ignoredSuperclasses }
+        val extendsString = if (supertypes.isNotEmpty()) {
+            " extends " + supertypes
+                .map { formatKType(it).formatWithoutParenthesis() }
                 .joinToString(", ")
         } else ""
 

--- a/src/test/kotlin/me/ntrrgc/tsGenerator/tests/generatorTests.kt
+++ b/src/test/kotlin/me/ntrrgc/tsGenerator/tests/generatorTests.kt
@@ -24,6 +24,7 @@ import me.ntrrgc.tsGenerator.onlyOnSubclassesOf
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import java.beans.Introspector
+import java.time.Instant
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
@@ -88,7 +89,7 @@ class ClassWithComplexNullables(
 class ClassWithNullableList(
     val strings: List<String>?
 )
-class GenericClass<A, out B, out C: List<Any>>(
+open class GenericClass<A, out B, out C: List<Any>>(
     val a: A,
     val b: List<B?>,
     val c: C,
@@ -96,6 +97,7 @@ class GenericClass<A, out B, out C: List<Any>>(
 )
 open class BaseClass(val a: Int)
 class DerivedClass(val b: List<String>): BaseClass(4)
+class GenericDerivedClass<B>(a: Empty, b: List<B?>, c: ArrayList<String>): GenericClass<Empty, B, ArrayList<String>>(a, b, c, a)
 class ClassWithMethods(val propertyMethod: () -> Int) {
     fun regularMethod() = 4
 }
@@ -232,6 +234,22 @@ interface ClassWithMember {
     """, """
     interface BaseClass {
         a: int;
+    }
+    """))
+    }
+
+    it("handles GenericDerivedClass") {
+        assertGeneratedCode(GenericDerivedClass::class, setOf("""
+    interface GenericClass<A, B, C extends any[]> {
+        a: A;
+        b: (B | null)[];
+        c: C;
+    }
+    ""","""
+    interface Empty {
+    }
+    ""","""
+    interface GenericDerivedClass<B> extends GenericClass<Empty, B, string[]> {
     }
     """))
     }


### PR DESCRIPTION
Previously extending a class from a generic super class would not translate correctly.
ie.

    class BaseClass<T>;
    class DerivedClass: BaseClass<String>

would generate:
 
    interface BaseClass<T> {}
    interface DerivedClass extends BaseClass {} /// <-- missing <string>
