### PR TITLE
Added formatType to public api

### DIFF
--- a/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
+++ b/src/main/kotlin/me/ntrrgc/tsGenerator/TypeScriptGenerator.kt
@@ -23,7 +23,6 @@ import kotlin.reflect.*
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaType
 
 /**
@@ -266,4 +265,8 @@ class TypeScriptGenerator(
 
     val individualDefinitions: Set<String>
         get() = generatedDefinitions.toSet()
+
+    fun formatType(kType: KType): String {
+        return formatKType(kType).formatWithoutParenthesis()
+    }
 }


### PR DESCRIPTION
Nice project :+1: . I'm using it to generate Promise-based http client API in addition to DTOs, and for that reason I needed to add formatType to the public API.

Then it's possible to do something like this to generate function signature:
```
val gen = TypeScriptGenerator(...)

val typescript = """function callMyApi(${param.name}: ${gen.formatType(param.type)}): Promise<${gen.formatType(returnType)}> {
    return http.get(...)
}
"""
```
